### PR TITLE
Fix: cast booleans

### DIFF
--- a/src/convert.spec.ts
+++ b/src/convert.spec.ts
@@ -116,7 +116,7 @@ describe('convert()', () => {
 		).toThrow())
 
 	// @see https://github.com/NordicSemiconductor/asset-tracker-cloud-coiote-aws-converter-js/issues/13
-	it('should convert object which contains the minimum allowed timestamp value as prop', () => {
+	it('should convert object that contains the minimum allowed timestamp value as prop', () => {
 		expect(
 			convert({
 				Location: {

--- a/src/schema-conversion/convertResource.spec.ts
+++ b/src/schema-conversion/convertResource.spec.ts
@@ -2,10 +2,10 @@ import { convertValue } from './convertResource'
 
 describe('convertValue', () => {
 	it.each([
-		['true', 'boolean', 1],
-		['false', 'boolean', 0],
-		['1', 'boolean', 1],
-		['0', 'boolean', 0],
+		['true', 'boolean', true],
+		['false', 'boolean', false],
+		['false', 'integer', 0], // special integer/boolean case
+		['true', 'integer', 1], // special integer/boolean case
 		['hello world', 'string', 'hello world'],
 		['10', 'number', 10],
 		['100', 'integer', 100],

--- a/src/schema-conversion/convertResource.spec.ts
+++ b/src/schema-conversion/convertResource.spec.ts
@@ -1,4 +1,209 @@
-import { convertValue } from './convertResource'
+import { convertResource, convertValue } from './convertResource'
+
+describe('convertResource', () => {
+	it.each([
+		['23', 'false', 0],
+		['6', 'false', 0],
+		['12', { noValue: true }, null],
+		['3', 0, 0],
+	])(
+		"should convert prop '%s' from LwM2M Server object. Value: '%s' Expected: %s",
+		(propId, value, expected) => {
+			const LwM2MServerSchema = {
+				type: 'object',
+				$id: 'https://github.com/OpenMobileAlliance/lwm2m-registry/raw/prod/1.xml',
+				title: 'LwM2M Server',
+				description:
+					'This LwM2M Objects provides the data related to a LwM2M Server. A Bootstrap-Server has no such an Object Instance associated to it. LWM2MVersion: 1.2 ObjectVersion: 1.2 MultipleInstances: true Mandatory: true',
+				additionalProperties: false,
+				properties: {
+					'0': {
+						type: 'integer',
+						minimum: 1,
+						maximum: 65534,
+						title: 'Short Server ID',
+						description: 'Used as link to associate server Object Instance.',
+					},
+					'1': {
+						type: 'integer',
+						title: 'Lifetime',
+						description:
+							'Specify the lifetime of the registration in seconds (see Client Registration Interface). If the value is set to 0, the lifetime is infinite. Units: s.',
+					},
+					'2': {
+						type: 'integer',
+						title: 'Default Minimum Period',
+						description:
+							'The default value the LwM2M Client should use for the Minimum Period of an Observation in the absence of this parameter being included in an Observation.\r\n' +
+							'If this Resource doesn’t exist, the default value is 0. Units: s.',
+					},
+					'3': {
+						type: 'integer',
+						title: 'Default Maximum Period',
+						description:
+							'The default value the LwM2M Client should use for the Maximum Period of an Observation in the absence of this parameter being included in an Observation. Units: s.',
+					},
+					'5': {
+						type: 'integer',
+						title: 'Disable Timeout',
+						description:
+							'A period to disable the Server. After this period, the LwM2M Client MUST perform registration process to the Server. If this Resource is not set, a default timeout value is 86400 (1 day). Units: s.',
+					},
+					'6': {
+						type: 'integer',
+						minimum: 0,
+						maximum: 1,
+						title: 'Notification Storing When Disabled or Offline',
+						description:
+							'If true, the LwM2M Client stores "Notify" operations to the LwM2M Server while the LwM2M Server account is disabled or the LwM2M Client is offline. After the LwM2M Server account is enabled or the LwM2M Client is online, the LwM2M Client reports the stored "Notify" operations to the Server.\r\n' +
+							'If false, the LwM2M Client discards all the "Notify" operations or temporarily disables the Observe function while the LwM2M Server is disabled or the LwM2M Client is offline.\r\n' +
+							'The default value is true.\r\n' +
+							'The maximum number of storing Notifications per Server is up to the implementation.',
+					},
+					'7': {
+						type: 'string',
+						title: 'Binding',
+						description:
+							'The possible values are those listed in the LwM2M Core Specification. This Resource defines the transport binding configured for the LwM2M Client.\r\n' +
+							'If the LwM2M Client supports the binding specified in this Resource, the LwM2M Client MUST use that transport for the Current Binding Mode.',
+					},
+					'10': {
+						type: 'string',
+						pattern: '^dd:dd$',
+						title: 'APN Link',
+						description:
+							'If this resource is defined, it provides a link to the APN connection profile Object Instance (OMNA registered Object ID:11) to be used to communicate with this server.',
+					},
+					'11': {
+						type: 'integer',
+						minimum: 0,
+						maximum: 255,
+						title: 'TLS-DTLS Alert Code',
+						description:
+							'If this resource is defined, it contains the most recent TLS / DTLS alert message received from the LwM2M Server respective represented by the AlertDescription defined in Section 7.2 of RFC 5246. This resource set by the LwM2M Client may help the LwM2M Bootstrap-Server to determine the cause of TLS/DTLS connection failure with the respective LwM2M Server.',
+					},
+					'12': {
+						type: 'integer',
+						unixTimestamp: true,
+						title: 'Last Bootstrapped',
+						description:
+							'If this resource is defined, it represents the last time that the bootstrap server updated this LwM2M Server Account. The LwM2M Client is responsible for updating this value. When the Bootstrap Server detects that this LwM2M Server Account is "out-of-date", the Bootstrap Server can update the LwM2M Server Account as represented by the LwM2M Server object instance. Unix Time. A signed integer representing the number of seconds since Jan 1 st, 1970 in the UTC time zone.',
+					},
+					'13': {
+						type: 'integer',
+						title: 'Registration Priority Order',
+						description:
+							'The LwM2M Client sequences the LwM2M Server registrations in increasing order of this value. If this value is not defined, registration attempts to this server are not impacted by other server registrations.',
+					},
+					'14': {
+						type: 'integer',
+						title: 'Initial Registration Delay Timer',
+						description:
+							'The delay, in seconds, before registration is attempted for this LwM2M Server based upon the completion of registration of the previous LwM2M Server in the registration order. This is only applied until the first successful registration after a successful bootstrapping sequence. Units: s.',
+					},
+					'15': {
+						type: 'integer',
+						minimum: 0,
+						maximum: 1,
+						title: 'Registration Failure Block',
+						description:
+							'When set to true and registration to this LwM2M server fails, the LwM2M Client blocks registration to other servers in the order. When set to false, the LwM2M Client proceeds with registration to the next server in the order.',
+					},
+					'16': {
+						type: 'integer',
+						minimum: 0,
+						maximum: 1,
+						title: 'Bootstrap on Registration Failure',
+						description:
+							'If set to true, this indicates that the LwM2M Client should re-bootstrap when either registration is explicitly rejected by the LwM2M Server or registration is considered as failing as dictated by the other resource settings. If set to false, the LwM2M Client will continue with the registration attempts as dictated by the other resource settings.',
+					},
+					'17': {
+						type: 'integer',
+						title: 'Communication Retry Count',
+						description:
+							'The number of successive communication attempts before which a communication sequence is considered as failed.',
+					},
+					'18': {
+						type: 'integer',
+						title: 'Communication Retry Timer',
+						description:
+							'The delay, in seconds, between successive communication attempts in a communication sequence. This value is multiplied by two to the power of the communication retry attempt minus one (2**(retry attempt-1)) to create an exponential back-off. Units: s.',
+					},
+					'19': {
+						type: 'integer',
+						title: 'Communication Sequence Delay Timer',
+						description:
+							'The delay, in seconds, between successive communication sequences. A communication sequence is defined as the exhaustion of the Communication Retry Count and Communication Retry Timer values. A communication sequence can be applied to server registrations or bootstrapping attempts. MAX_VALUE means do not perform another communication sequence. Units: s.',
+					},
+					'20': {
+						type: 'integer',
+						title: 'Communication Sequence Retry Count',
+						description:
+							'The number of successive communication sequences before which a registration attempt is considered as failed.',
+					},
+					'21': {
+						type: 'integer',
+						minimum: 0,
+						maximum: 1,
+						title: 'Trigger',
+						description: `Using the Trigger Resource a LwM2M Client can indicate whether it is reachable over SMS (value set to 'true') or not (value set to 'false'). The default value (resource not present) is 'false'. When set to 'true' the LwM2M Server MAY, for example, request the LwM2M Client to perform operations, such as the "Update" operation by sending an "Execute" operation on "Registration Update Trigger" Resource via SMS. No SMS response is expected for such a message.`,
+					},
+					'22': {
+						type: 'string',
+						title: 'Preferred Transport',
+						description:
+							'Only a single transport binding SHALL be present. When the LwM2M client supports multiple transports, it MAY use this transport to initiate a connection. This resource can also be used to switch between multiple transports e.g. a non-IP device can switch to UDP transport to perform firmware updates.',
+					},
+					'23': {
+						type: 'integer',
+						minimum: 0,
+						maximum: 1,
+						title: 'Mute Send',
+						description:
+							'If true or the Resource is not present, the LwM2M Client Send command capability is de-activated. \r\n' +
+							'If false, the LwM2M Client Send Command capability is activated.',
+					},
+					'24': {
+						type: 'array',
+						minItems: 1,
+						items: [Object],
+						title: 'Alternate APN Links',
+						description:
+							'If this resource is defined, it provides links to alternate APN connection profile Object Instance (OMNA registered Object ID:11) to be used to communicate with this server if Resource 10 has configuration conflicts.',
+					},
+					'25': {
+						type: 'array',
+						minItems: 1,
+						items: [Object],
+						title: 'Supported Server Versions',
+						description:
+							'This resource provides the supported enabler versions of the server to the client as a set of strings. Format for each string is 1*DIGIT"."1*DIGIT"."1*DIGIT where the third DIGIT is optional.',
+					},
+					'26': {
+						type: 'integer',
+						minimum: 0,
+						maximum: 1,
+						title: 'Default Notification Mode',
+						description:
+							'This resource indicates the default mode for observations to be sent: 0 = Non-Confirmable, 1 = Confirmable.',
+					},
+					'27': {
+						type: 'integer',
+						minimum: 0,
+						maximum: 255,
+						title: 'Profile ID Hash Algorithm',
+						description:
+							"If this resource is defined, it contains the hash algorithm the LwM2M Server would prefer the LwM2M Client to use with the dynamically generated mode of creating Profile IDs. The numerical ID value of the 'Suite Identifiers' registered by RFC 6920 is used in this Resource.",
+					},
+				},
+				required: ['0', '1', '6', '7'],
+			}
+			expect(
+				convertResource(LwM2MServerSchema as any, propId, value as any),
+			).toEqual(expected)
+		},
+	)
+})
 
 describe('convertValue', () => {
 	it.each([

--- a/src/schema-conversion/convertResource.spec.ts
+++ b/src/schema-conversion/convertResource.spec.ts
@@ -1,0 +1,19 @@
+import { convertValue } from './convertResource'
+
+describe('convertValue', () => {
+	it.each([
+		['true', 'boolean', 1],
+		['false', 'boolean', 0],
+		['1', 'boolean', 1],
+		['0', 'boolean', 0],
+		['hello world', 'string', 'hello world'],
+		['10', 'number', 10],
+		['100', 'integer', 100],
+		['1970-01-01T00:00:00Z', 'timestamp', 0],
+		['', '', null],
+	])(
+		"should convert value: '%s' which is type: '%s' to: %s",
+		(value, type: any, expected) =>
+			expect(convertValue(value, type)).toEqual(expected),
+	)
+})

--- a/src/schema-conversion/convertResource.ts
+++ b/src/schema-conversion/convertResource.ts
@@ -32,6 +32,14 @@ export const convertResource = (
 
 	return convertValue(value as string, resource.type)
 }
+
+/**
+ * Cast value to expected type
+ *
+ * Boolean case return number type because in LwM2M Boolean is an 8 bit
+ * unsigned integer with the value 0 for False and the value 1 for True
+ * @see https://www.openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/OMA-TS-LightweightM2M_Core-V1_1_1-20190617-A.pdf Pag 106 Table: C.-1 Data Types
+ */
 export const convertValue = (
 	value: string,
 	type: 'integer' | 'number' | 'boolean' | 'string' | 'timestamp',
@@ -44,7 +52,7 @@ export const convertValue = (
 		case 'number':
 			return parseFloat(value)
 		case 'boolean':
-			return value === '1' ? true : false // value === 'true' || value === '1'
+			return value === 'true' || value === '1' ? 1 : 0
 		case 'string':
 			return value
 		default:

--- a/src/schema-conversion/convertResource.ts
+++ b/src/schema-conversion/convertResource.ts
@@ -36,8 +36,8 @@ export const convertResource = (
 /**
  * Cast value to expected type
  *
- * Boolean case return number type because in LwM2M Boolean is an 8 bit
- * unsigned integer with the value 0 for False and the value 1 for True
+ * Integer case contain a special validation because in LwM2M, Boolean is an
+ * 8 bit unsigned integer with the value 0 for False and the value 1 for True
  * @see https://www.openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/OMA-TS-LightweightM2M_Core-V1_1_1-20190617-A.pdf Pag 106 Table: C.-1 Data Types
  */
 export const convertValue = (
@@ -47,12 +47,16 @@ export const convertValue = (
 	switch (type) {
 		case 'timestamp':
 			return new Date(value).getTime() / 1000
-		case 'integer':
+		case 'integer': {
+			if (value === 'true' || value === 'false') {
+				return value === 'true' ? 1 : 0
+			}
 			return parseInt(value, 10)
+		}
 		case 'number':
 			return parseFloat(value)
 		case 'boolean':
-			return value === 'true' || value === '1' ? 1 : 0
+			return value === 'true' ? true : false
 		case 'string':
 			return value
 		default:

--- a/src/schema-conversion/convertToArray.spec.ts
+++ b/src/schema-conversion/convertToArray.spec.ts
@@ -75,6 +75,80 @@ describe('convertToArray()', () => {
 				{ '0': 195, '1': 0, '2': 300, '3': -16, '4': -119, '5': 23 },
 			],
 		],
+		[
+			{
+				'0': {
+					'APN Link': {
+						noValue: true,
+					},
+					Binding: 'U',
+					'Bootstrap on Registration Failure': {
+						noValue: true,
+					},
+					'Bootstrap-Request Trigger': {
+						noValue: true,
+					},
+					'Communication Retry Count': {
+						noValue: true,
+					},
+					'Communication Retry Timer': {
+						noValue: true,
+					},
+					'Communication Sequence Delay Timer': {
+						noValue: true,
+					},
+					'Communication Sequence Retry Count': {
+						noValue: true,
+					},
+					'Default Maximum Period': '0',
+					'Default Minimum Period': '0',
+					Disable: {
+						noValue: true,
+					},
+					'Disable Timeout': '86400',
+					'Initial Registration Delay Timer': {
+						noValue: true,
+					},
+					'Last Bootstrapped': {
+						noValue: true,
+					},
+					Lifetime: '43200',
+					'Mute Send': 'false',
+					'Notification Storing When Disabled or Offline': 'false',
+					'Preferred Transport': '',
+					'Registration Failure Block': {
+						noValue: true,
+					},
+					'Registration Priority Order': {
+						noValue: true,
+					},
+					'Registration Update Trigger': {
+						noValue: true,
+					},
+					'Short Server ID': '101',
+					'TLS-DTLS Alert Code': {
+						noValue: true,
+					},
+					Trigger: {
+						noValue: true,
+					},
+				},
+			},
+			'1:1.2@1.2',
+			[
+				{
+					'0': 101,
+					'1': 43200,
+					'2': 0,
+					'22': '',
+					'23': 0,
+					'3': 0,
+					'5': 86400,
+					'6': 0,
+					'7': 'U',
+				},
+			],
+		],
 	])(
 		'should convert object definition %j for object %s using json schema to %j',
 		(objectDefinition, urn, expected) =>


### PR DESCRIPTION
in the LwM2M documentation ([Pag 106 Table: C.-1 Data Types ](https://www.openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/OMA-TS-LightweightM2M_Core-V1_1_1-20190617-A.pdf) ), Boolean is defined as an 8 bit unsigned integer with the value 0 for False and the value 1 for True. 

So, the `convertValue` method was updated in order to address to that definition and unit tests were added in order to ensure the expected functionality on different steps. 